### PR TITLE
Improve tier sorting to support Anilist scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ How to run locally
   <li>git clone https://github.com/Qnnie/AnimeTierList</li>
   <li>cd AnimeTierList</li>
   <li>npm install</li>
-  <li>node app.js</li>
+  <li>node src/app.js</li>
 </ol>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ How to run locally
   <li>git clone https://github.com/Qnnie/AnimeTierList</li>
   <li>cd AnimeTierList</li>
   <li>npm install</li>
-  <li>node src/app.js</li>
+  <li>node app.js</li>
 </ol>
 

--- a/src/controllers/anilist.js
+++ b/src/controllers/anilist.js
@@ -31,10 +31,10 @@ const anilist = (query, variables) => {
  */
 const transformAnime = anime => ({
     score: anime.score,
-    title: anime.media.title.english,
+    title: anime.media.title.userPreferred,
     image: anime.media.coverImage.medium,
     image_large: anime.media.coverImage.large,
-    url: `https://anilist.co/anime/${anime.id}`,
+    url: `https://anilist.co/anime/${anime.mediaId}`,
     tier: helpers.tiers[anime.score]
 });
 

--- a/src/controllers/anilist.js
+++ b/src/controllers/anilist.js
@@ -31,11 +31,11 @@ const anilist = (query, variables) => {
  */
 const transformAnime = anime => ({
     score: anime.score,
-    title: anime.media.title.userPreferred,
+    title: anime.media.title.english,
     image: anime.media.coverImage.medium,
     image_large: anime.media.coverImage.large,
-    url: `https://anilist.co/anime/${anime.mediaId}`,
-    tier: helpers.tiers[anime.score]
+    url: `https://anilist.co/anime/${anime.id}`,
+    tier: helpers.getAnimeTier(anime.score)
 });
 
 /**

--- a/src/controllers/mal.js
+++ b/src/controllers/mal.js
@@ -72,7 +72,7 @@ const transformAnime = anime => ({
     title: anime.animeTitle,
     image: anime.animeImagePath.replace("/r/96x136", ""),
     url: `https://myanimelist.net${anime.animeUrl}`,
-    tier: helpers.tiers[anime.score]
+    tier: helpers.getAnimeTier(anime.score)
 });
 
 /**

--- a/src/graphql/userAnimes.graphql
+++ b/src/graphql/userAnimes.graphql
@@ -3,7 +3,7 @@ query($user: String) {
     lists {
       name
       entries {
-        id
+        mediaId
         score
         media {
           coverImage {

--- a/src/graphql/userAnimes.graphql
+++ b/src/graphql/userAnimes.graphql
@@ -3,8 +3,8 @@ query($user: String) {
     lists {
       name
       entries {
-        mediaId
-        score
+        id
+        score(format: POINT_10_DECIMAL)
         media {
           coverImage {
             medium

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,19 +1,44 @@
-/**
- * Definition of what the ranks
- * that Anilist has corresponds to.
- */
-const tiers = {
-    10: "SS",
-    9: "S",
-    8: "A",
-    7: "B",
-    6: "C",
-    5: "D",
-    4: "D",
-    3: "F",
-    2: "F",
-    1: "F",
-    0: "unranked",
+const tierBreakpoints = [
+    {
+        tier: 'SS',
+        breakpoint: 10
+    },
+    {
+        tier: 'S',
+        breakpoint: 9
+    },
+    {
+        tier: 'A',
+        breakpoint: 8
+    },
+    {
+        tier: 'B',
+        breakpoint: 7
+    },
+    {
+        tier: 'C',
+        breakpoint: 6
+    },
+    {
+        tier: 'D',
+        breakpoint: 4
+    },
+    {
+        tier: 'F',
+        breakpoint: 0
+    }
+]
+
+const getAnimeTier = (score) => {
+    if (score === 0) {
+        return 'unranked'
+    }
+
+    for (let i = 0; i < tierBreakpoints.length; i++) {
+        if (score >= tierBreakpoints[i].breakpoint) {
+            return tierBreakpoints[i].tier
+        } 
+    }
 }
 
 /**
@@ -47,6 +72,6 @@ const tallyAnimeScores = (animes) => {
 }
 
 module.exports = {
-    tiers,
+    getAnimeTier,
     tallyAnimeScores
 }


### PR DESCRIPTION
Anilist allows users to score with a few different methods. This PR normalizes that output to 10 point decimal and updates the tier sorting to be more flexible around that. 