### PR TITLE
feat: lazy load posters

### DIFF
--- a/src/views/tierList.hbs
+++ b/src/views/tierList.hbs
@@ -19,7 +19,7 @@
         {{#> tier tier=this.tier}}
             {{#each this.animes}}
                 <a href="{{this.url}}" target="_blank"><div class="thumbnail-container">
-                <img class="thumbnail" src='{{this.image}}'><div class="title-display">{{this.title}}</div></img></div></a>        
+                <img class="thumbnail" src='{{this.image}}' loading="lazy"><div class="title-display">{{this.title}}</div></img></div></a>
             {{/each}}
         {{/tier}}
     {{/if}}


### PR DESCRIPTION
Modified the tier list to make use of [lazy loading](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading) with the [`loading`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) attribute. Posters are only fetched when they're about to scroll into view - this is a significant improvement for users with huge libraries.

Supported in all modern browsers except Safari, which will behave the same as before this PR